### PR TITLE
Raise exception when file doesn't exist

### DIFF
--- a/pygments.js
+++ b/pygments.js
@@ -166,10 +166,14 @@ pygments.merge_options = function(options) {
 pygments.stringize = function(target, force) {
   force = (force===undefined ? false : force);
 
-  if(exists(target) && !force) {
-    var target_stats = fs.statSync(target);
-    if(target_stats.isFile()) {
-      return fs.readFileSync(target);
+  if(!force) {
+    if(exists(target)) {
+      var target_stats = fs.statSync(target);
+      if(target_stats.isFile()) {
+        return fs.readFileSync(target);
+      }
+    } else {
+      throw new Error("File not found: "+target);
     }
   }
 


### PR DESCRIPTION
When caller accidentally submits a pathname that doesn't exist, pygments.js colorizes the path. Unless force:true is specified it would be better to raise an exception, letting caller know they passed an incorrect pathname.
